### PR TITLE
Reworking SummonEffectsTable, L2PetInstance, L2ServitorInstance.

### DIFF
--- a/L2J_Server/java/com/l2jserver/gameserver/data/sql/impl/SummonEffectsTable.java
+++ b/L2J_Server/java/com/l2jserver/gameserver/data/sql/impl/SummonEffectsTable.java
@@ -18,11 +18,17 @@
  */
 package com.l2jserver.gameserver.data.sql.impl;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
 
+import com.l2jserver.gameserver.model.actor.L2Summon;
 import com.l2jserver.gameserver.model.actor.instance.L2PcInstance;
+import com.l2jserver.gameserver.model.actor.instance.L2PetInstance;
+import com.l2jserver.gameserver.model.actor.instance.L2ServitorInstance;
 import com.l2jserver.gameserver.model.skills.Skill;
 
 /**
@@ -37,12 +43,7 @@ public class SummonEffectsTable
 	// ---> key: servitorSkillId, value: Effects list
 	private final Map<Integer, Map<Integer, Map<Integer, List<SummonEffect>>>> _servitorEffects = new HashMap<>();
 	
-	public Map<Integer, Map<Integer, Map<Integer, List<SummonEffect>>>> getServitorEffectsOwner()
-	{
-		return _servitorEffects;
-	}
-	
-	public Map<Integer, List<SummonEffect>> getServitorEffects(L2PcInstance owner)
+	private Map<Integer, List<SummonEffect>> getServitorEffects(L2PcInstance owner)
 	{
 		final Map<Integer, Map<Integer, List<SummonEffect>>> servitorMap = _servitorEffects.get(owner.getObjectId());
 		if (servitorMap == null)
@@ -52,15 +53,107 @@ public class SummonEffectsTable
 		return servitorMap.get(owner.getClassIndex());
 	}
 	
+	private List<SummonEffect> getServitorEffects(L2PcInstance owner, int referenceSkill)
+	{
+		return containsOwner(owner) ? getServitorEffects(owner).get(referenceSkill) : null;
+	}
+	
+	private boolean containsOwner(L2PcInstance owner)
+	{
+		return _servitorEffects.getOrDefault(owner.getObjectId(), Collections.emptyMap()).containsKey(owner.getClassIndex());
+	}
+	
+	private void removeEffects(List<SummonEffect> effects, int skillId)
+	{
+		if ((effects != null) && !effects.isEmpty())
+		{
+			for (SummonEffect effect : effects)
+			{
+				final Skill skill = effect.getSkill();
+				if ((skill != null) && (skill.getId() == skillId))
+				{
+					effects.remove(effect);
+				}
+			}
+		}
+	}
+	
+	private void applyEffects(L2Summon summon, List<SummonEffect> summonEffects)
+	{
+		if (summonEffects == null)
+		{
+			return;
+		}
+		for (SummonEffect se : summonEffects)
+		{
+			if (se != null)
+			{
+				se.getSkill().applyEffects(summon, summon, false, se.getEffectCurTime());
+			}
+		}
+	}
+	
+	public boolean containsSkill(L2PcInstance owner, int referenceSkill)
+	{
+		return containsOwner(owner) && getServitorEffects(owner).containsKey(referenceSkill);
+	}
+	
+	public void clearServitorEffects(L2PcInstance owner, int referenceSkill)
+	{
+		if (containsOwner(owner))
+		{
+			
+			getServitorEffects(owner).getOrDefault(referenceSkill, Collections.emptyList()).clear();
+		}
+	}
+	
+	public void addServitorEffect(L2PcInstance owner, int referenceSkill, Skill skill, int effectCurTime)
+	{
+		_servitorEffects.putIfAbsent(owner.getObjectId(), new HashMap<Integer, Map<Integer, List<SummonEffect>>>());
+		_servitorEffects.get(owner.getObjectId()).putIfAbsent(owner.getClassIndex(), new HashMap<Integer, List<SummonEffect>>());
+		getServitorEffects(owner).putIfAbsent(referenceSkill, new CopyOnWriteArrayList<SummonEffect>());
+		getServitorEffects(owner).get(referenceSkill).add(new SummonEffect(skill, effectCurTime));
+	}
+	
+	public void removeServitorEffects(L2PcInstance owner, int referenceSkill, int skillId)
+	{
+		removeEffects(getServitorEffects(owner, referenceSkill), skillId);
+	}
+	
+	public void applyServitorEffects(L2ServitorInstance l2ServitorInstance, L2PcInstance owner, int referenceSkill)
+	{
+		applyEffects(l2ServitorInstance, getServitorEffects(owner, referenceSkill));
+	}
+	
 	/** Pets **/
 	private final Map<Integer, List<SummonEffect>> _petEffects = new HashMap<>(); // key: petItemObjectId, value: Effects list
 	
-	public Map<Integer, List<SummonEffect>> getPetEffects()
+	public void addPetEffect(int controlObjectId, Skill skill, int effectCurTime)
 	{
-		return _petEffects;
+		_petEffects.putIfAbsent(controlObjectId, new ArrayList<>()).add(new SummonEffect(skill, effectCurTime));
 	}
 	
-	public class SummonEffect
+	public boolean containsPetId(int controlObjectId)
+	{
+		return _petEffects.containsKey(controlObjectId);
+	}
+	
+	public void applyPetEffects(L2PetInstance l2PetInstance, int controlObjectId)
+	{
+		applyEffects(l2PetInstance, _petEffects.get(controlObjectId));
+	}
+	
+	public void clearPetEffects(int controlObjectId)
+	{
+		_petEffects.getOrDefault(controlObjectId, Collections.emptyList()).clear();
+	}
+	
+	public void removePetEffects(int controlObjectId, int skillId)
+	{
+		removeEffects(_petEffects.get(controlObjectId), skillId);
+	}
+	
+	private class SummonEffect
 	{
 		Skill _skill;
 		int _effectCurTime;

--- a/L2J_Server/java/com/l2jserver/gameserver/model/actor/instance/L2ServitorInstance.java
+++ b/L2J_Server/java/com/l2jserver/gameserver/model/actor/instance/L2ServitorInstance.java
@@ -21,12 +21,8 @@ package com.l2jserver.gameserver.model.actor.instance;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Map;
-import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.Future;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -36,7 +32,6 @@ import com.l2jserver.L2DatabaseFactory;
 import com.l2jserver.gameserver.ThreadPoolManager;
 import com.l2jserver.gameserver.data.sql.impl.CharSummonTable;
 import com.l2jserver.gameserver.data.sql.impl.SummonEffectsTable;
-import com.l2jserver.gameserver.data.sql.impl.SummonEffectsTable.SummonEffect;
 import com.l2jserver.gameserver.datatables.SkillData;
 import com.l2jserver.gameserver.enums.InstanceType;
 import com.l2jserver.gameserver.model.L2Object;
@@ -232,22 +227,7 @@ public class L2ServitorInstance extends L2Summon implements Runnable
 	public final void stopSkillEffects(boolean removed, int skillId)
 	{
 		super.stopSkillEffects(removed, skillId);
-		final Map<Integer, List<SummonEffect>> servitorEffects = SummonEffectsTable.getInstance().getServitorEffects(getOwner());
-		if (servitorEffects != null)
-		{
-			final List<SummonEffect> effects = servitorEffects.get(getReferenceSkill());
-			if ((effects != null) && !effects.isEmpty())
-			{
-				for (SummonEffect effect : effects)
-				{
-					final Skill skill = effect.getSkill();
-					if ((skill != null) && (skill.getId() == skillId))
-					{
-						effects.remove(effect);
-					}
-				}
-			}
-		}
+		SummonEffectsTable.getInstance().removeServitorEffects(getOwner(), getReferenceSkill(), skillId);
 	}
 	
 	@Override
@@ -278,10 +258,7 @@ public class L2ServitorInstance extends L2Summon implements Runnable
 		}
 		
 		// Clear list for overwrite
-		if (SummonEffectsTable.getInstance().getServitorEffectsOwner().getOrDefault(getOwner().getObjectId(), Collections.emptyMap()).containsKey(getOwner().getClassIndex()))
-		{
-			SummonEffectsTable.getInstance().getServitorEffects(getOwner()).getOrDefault(getReferenceSkill(), Collections.emptyList()).clear();
-		}
+		SummonEffectsTable.getInstance().clearServitorEffects(getOwner(), getReferenceSkill());
 		
 		try (Connection con = L2DatabaseFactory.getInstance().getConnection();
 			PreparedStatement statement = con.prepareStatement(DELETE_SKILL_SAVE))
@@ -342,21 +319,7 @@ public class L2ServitorInstance extends L2Summon implements Runnable
 						ps2.setInt(7, ++buff_index);
 						ps2.execute();
 						
-						// XXX: Rework me!
-						if (!SummonEffectsTable.getInstance().getServitorEffectsOwner().containsKey(getOwner().getObjectId()))
-						{
-							SummonEffectsTable.getInstance().getServitorEffectsOwner().put(getOwner().getObjectId(), new HashMap<Integer, Map<Integer, List<SummonEffect>>>());
-						}
-						if (!SummonEffectsTable.getInstance().getServitorEffectsOwner().get(getOwner().getObjectId()).containsKey(getOwner().getClassIndex()))
-						{
-							SummonEffectsTable.getInstance().getServitorEffectsOwner().get(getOwner().getObjectId()).put(getOwner().getClassIndex(), new HashMap<Integer, List<SummonEffect>>());
-						}
-						if (!SummonEffectsTable.getInstance().getServitorEffects(getOwner()).containsKey(getReferenceSkill()))
-						{
-							SummonEffectsTable.getInstance().getServitorEffects(getOwner()).put(getReferenceSkill(), new CopyOnWriteArrayList<SummonEffect>());
-						}
-						
-						SummonEffectsTable.getInstance().getServitorEffects(getOwner()).get(getReferenceSkill()).add(SummonEffectsTable.getInstance().new SummonEffect(skill, info.getTime()));
+						SummonEffectsTable.getInstance().addServitorEffect(getOwner(), getReferenceSkill(), skill, info.getTime());
 					}
 				}
 			}
@@ -377,7 +340,7 @@ public class L2ServitorInstance extends L2Summon implements Runnable
 		
 		try (Connection con = L2DatabaseFactory.getInstance().getConnection())
 		{
-			if (!SummonEffectsTable.getInstance().getServitorEffectsOwner().containsKey(getOwner().getObjectId()) || !SummonEffectsTable.getInstance().getServitorEffectsOwner().get(getOwner().getObjectId()).containsKey(getOwner().getClassIndex()) || !SummonEffectsTable.getInstance().getServitorEffects(getOwner()).containsKey(getReferenceSkill()))
+			if (!SummonEffectsTable.getInstance().containsSkill(getOwner(), getReferenceSkill()))
 			{
 				try (PreparedStatement statement = con.prepareStatement(RESTORE_SKILL_SAVE))
 				{
@@ -396,23 +359,9 @@ public class L2ServitorInstance extends L2Summon implements Runnable
 								continue;
 							}
 							
-							// XXX: Rework me!
 							if (skill.hasEffects(EffectScope.GENERAL))
 							{
-								if (!SummonEffectsTable.getInstance().getServitorEffectsOwner().containsKey(getOwner().getObjectId()))
-								{
-									SummonEffectsTable.getInstance().getServitorEffectsOwner().put(getOwner().getObjectId(), new HashMap<Integer, Map<Integer, List<SummonEffect>>>());
-								}
-								if (!SummonEffectsTable.getInstance().getServitorEffectsOwner().get(getOwner().getObjectId()).containsKey(getOwner().getClassIndex()))
-								{
-									SummonEffectsTable.getInstance().getServitorEffectsOwner().get(getOwner().getObjectId()).put(getOwner().getClassIndex(), new HashMap<Integer, List<SummonEffect>>());
-								}
-								if (!SummonEffectsTable.getInstance().getServitorEffects(getOwner()).containsKey(getReferenceSkill()))
-								{
-									SummonEffectsTable.getInstance().getServitorEffects(getOwner()).put(getReferenceSkill(), new CopyOnWriteArrayList<SummonEffect>());
-								}
-								
-								SummonEffectsTable.getInstance().getServitorEffects(getOwner()).get(getReferenceSkill()).add(SummonEffectsTable.getInstance().new SummonEffect(skill, effectCurTime));
+								SummonEffectsTable.getInstance().addServitorEffect(getOwner(), getReferenceSkill(), skill, effectCurTime);
 							}
 						}
 					}
@@ -433,18 +382,7 @@ public class L2ServitorInstance extends L2Summon implements Runnable
 		}
 		finally
 		{
-			if (!SummonEffectsTable.getInstance().getServitorEffectsOwner().containsKey(getOwner().getObjectId()) || !SummonEffectsTable.getInstance().getServitorEffectsOwner().get(getOwner().getObjectId()).containsKey(getOwner().getClassIndex()) || !SummonEffectsTable.getInstance().getServitorEffects(getOwner()).containsKey(getReferenceSkill()))
-			{
-				return;
-			}
-			
-			for (SummonEffect se : SummonEffectsTable.getInstance().getServitorEffects(getOwner()).get(getReferenceSkill()))
-			{
-				if (se != null)
-				{
-					se.getSkill().applyEffects(this, this, false, se.getEffectCurTime());
-				}
-			}
+			SummonEffectsTable.getInstance().applyServitorEffects(this, getOwner(), getReferenceSkill());
 		}
 	}
 	


### PR DESCRIPTION
Moving common code to SummonEffectsTable.
Making L2PetInstance, L2ServitorInstance more intuitive by encapsulating
the details in SummonEffectsTable.
Reducing coupling with SummonEffectsTable and its data structures.