### PR TITLE
Fixing Pet Resurrection more than once issue

### DIFF
--- a/L2J_Server/java/com/l2jserver/gameserver/model/actor/instance/L2PcInstance.java
+++ b/L2J_Server/java/com/l2jserver/gameserver/model/actor/instance/L2PcInstance.java
@@ -10632,6 +10632,7 @@ public final class L2PcInstance extends L2Playable
 				}
 			}
 		}
+		_revivePet = false;
 		_reviveRequested = 0;
 		_revivePower = 0;
 	}


### PR DESCRIPTION
boolean _revivePet was setting true on reviveRequest indicating pet resurrection action and wasn't setting back to false after reviveAnswer call