### PR TITLE
Fix Antifeed and npe when the player tries to login

### DIFF
--- a/L2J_Server/java/com/l2jserver/gameserver/instancemanager/AntiFeedManager.java
+++ b/L2J_Server/java/com/l2jserver/gameserver/instancemanager/AntiFeedManager.java
@@ -157,7 +157,12 @@ public final class AntiFeedManager
 		
 		final AtomicInteger connectionCount = event.computeIfAbsent(addrHash, k -> new AtomicInteger());
 		
-		return connectionCount.getAndIncrement() < (max + Config.L2JMOD_DUALBOX_CHECK_WHITELIST.getOrDefault(addrHash, 0));
+		if ((connectionCount.get() + 1) <= (max + Config.L2JMOD_DUALBOX_CHECK_WHITELIST.getOrDefault(addrHash, 0)))
+		{
+			connectionCount.incrementAndGet();
+			return true;
+		}
+		return false;
 	}
 	
 	/**

--- a/L2J_Server/java/com/l2jserver/gameserver/network/serverpackets/AbstractHtmlPacket.java
+++ b/L2J_Server/java/com/l2jserver/gameserver/network/serverpackets/AbstractHtmlPacket.java
@@ -132,6 +132,11 @@ public abstract class AbstractHtmlPacket extends L2GameServerPacket
 	public final void runImpl()
 	{
 		L2PcInstance player = getClient().getActiveChar();
+		if (player == null)
+		{
+			return;
+		}
+		
 		player.clearHtmlActions(getScope());
 		
 		if (_disabledValidation)


### PR DESCRIPTION
## Summary

Fix Antifeed and NPE when the player tries to login and he reaches the max connections allowed from ip.

## Test plan

1) In L2JMods, change DualboxCheckMaxPlayersPerIP to 2 and remove '127.0.0.1' from DualboxCheckWhitelist.
2) Open 3 clients, login with two.
3) Try to login with the 3rd client, it should doesn't let you.
4) Then, logout with 2nd client and try to login again, it should let you.
5) Check the console to see if npe appears (it shouldn't)

## Report

http://www.l2jserver.com/forum/viewtopic.php?f=77&t=31377&p=187504#p187504