### PR TITLE
Drop period in LongTimeEvents fixed

### DIFF
--- a/L2J_Server/java/com/l2jserver/gameserver/model/event/LongTimeEvent.java
+++ b/L2J_Server/java/com/l2jserver/gameserver/model/event/LongTimeEvent.java
@@ -265,17 +265,21 @@ public class LongTimeEvent extends Quest
 	 */
 	protected void startEvent()
 	{
+		long currentTime = System.currentTimeMillis();
 		// Add drop
 		if (_dropList != null)
 		{
-			for (GeneralDropItem drop : _dropList)
+			if (currentTime < _dropPeriod.getEndDate().getTime())
 			{
-				EventDroplist.getInstance().addGlobalDrop(drop.getItemId(), drop.getMin(), drop.getMax(), (int) drop.getChance(), _dropPeriod);
+				for (GeneralDropItem drop : _dropList)
+				{
+					EventDroplist.getInstance().addGlobalDrop(drop.getItemId(), drop.getMin(), drop.getMax(), (int) drop.getChance(), _dropPeriod);
+				}
 			}
 		}
 		
 		// Add spawns
-		Long millisToEventEnd = _eventPeriod.getEndDate().getTime() - System.currentTimeMillis();
+		Long millisToEventEnd = _eventPeriod.getEndDate().getTime() - currentTime;
 		if (_spawnList != null)
 		{
 			for (NpcSpawn spawn : _spawnList)

--- a/L2J_Server/java/com/l2jserver/gameserver/script/DateRange.java
+++ b/L2J_Server/java/com/l2jserver/gameserver/script/DateRange.java
@@ -65,7 +65,8 @@ public class DateRange
 	
 	public boolean isWithinRange(Date date)
 	{
-		return date.after(_startDate) && date.before(_endDate);
+		return (date.equals(_startDate) || date.after(_startDate)) //
+			&& (date.equals(_endDate) || date.before(_endDate));
 	}
 	
 	public Date getEndDate()


### PR DESCRIPTION
## Summary

Drop period in LongTimeEvents fixed: it didn't consider the dates within the range if they were the same.
Extra: it avoids adding global drop if the current time is longer than the drop period end.

## Test plan

1) Go to ./data/scripts/events/HeavyMedal/ and open config.xml
2) Replace active="value" by active="27 02 2010-28 02 2016" dropPeriod="27 02 2010-27 06 2015" (the start date must be equals to test it)
3) Go to ./data/scripts.cfg and uncomment 'events/HeavyMedal/HeavyMedal.java'
4) Run your server. The mobs should drop event medals.

## Report

http://www.l2jserver.com/forum/viewtopic.php?f=77&t=31144

Reported by CostyKiller

Thank you!