### PR TITLE
Critical announcements on enterworld fixed

### DIFF
--- a/L2J_Server/java/com/l2jserver/gameserver/data/sql/impl/AnnouncementsTable.java
+++ b/L2J_Server/java/com/l2jserver/gameserver/data/sql/impl/AnnouncementsTable.java
@@ -112,7 +112,9 @@ public final class AnnouncementsTable
 		{
 			if (announce.isValid() && (announce.getType() == type))
 			{
-				player.sendPacket(new CreatureSay(0, Say2.ANNOUNCEMENT, player.getName(), announce.getContent()));
+				player.sendPacket(new CreatureSay(0, //
+				type == AnnouncementType.CRITICAL ? Say2.CRITICAL_ANNOUNCE : Say2.ANNOUNCEMENT, //
+				player.getName(), announce.getContent()));
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

Problem: On enterworld, the criticals announcements are displayed like normal announcements.

## Test plan

1) Add a Critical announce to be displayed on enterworld
2) Relog and you should see the critical announcements

## Report

http://www.l2jserver.com/forum/viewtopic.php?f=77&t=31397

Reported by JMD

Thank you!