### PR TITLE
Clan skills fixed: avoid adding to list skills already learned

### DIFF
--- a/L2J_Server/java/com/l2jserver/gameserver/data/xml/impl/SkillTreesData.java
+++ b/L2J_Server/java/com/l2jserver/gameserver/data/xml/impl/SkillTreesData.java
@@ -735,7 +735,7 @@ public final class SkillTreesData implements IXmlReader
 				final Skill oldSkill = clan.getSkills().get(skill.getSkillId());
 				if (oldSkill != null)
 				{
-					if (oldSkill.getLevel() < skill.getSkillLevel())
+					if ((oldSkill.getLevel() + 1) == skill.getSkillLevel())
 					{
 						result.add(skill);
 					}


### PR DESCRIPTION
## Summary

Problem: 

![l2jclanskills](https://cloud.githubusercontent.com/assets/4108820/8297513/a77e5bb8-1934-11e5-9c38-7fb92394a574.jpg)

## Test plan

1) Create a clan lvl 7 and learn all skills lvl 1
2) Set clan lvl 8 and go to Village Master to see the clan skills list to learn. You shouldn't see repeated skills with a level you already learned.

## Report

http://www.l2jserver.com/forum/viewtopic.php?f=77&t=31395

Reported by Midas, iChaosPaladin, Driad & valanths1990

Thank you!