### PR TITLE
Removed unnecesary send packet in Olys

### DIFF
--- a/src/main/java/com/l2jserver/gameserver/model/olympiad/AbstractOlympiadGame.java
+++ b/src/main/java/com/l2jserver/gameserver/model/olympiad/AbstractOlympiadGame.java
@@ -349,11 +349,15 @@ public abstract class AbstractOlympiadGame
 				player.untransform();
 			}
 			
+			if (player.isInOlympiadMode())
+			{
+				player.sendPacket(new ExOlympiadMode(0));
+			}
+			
 			player.setIsInOlympiadMode(false);
 			player.setIsOlympiadStart(false);
 			player.setOlympiadSide(-1);
 			player.setOlympiadGameId(-1);
-			player.sendPacket(new ExOlympiadMode(0));
 			
 			// Add Clan Skills
 			if (player.getClan() != null)


### PR DESCRIPTION
## Summary

Removed unnecesary send packet when the player is not in Olympiad mode, turning the characters invisibles.

## Report

http://www.l2jserver.com/forum/viewtopic.php?f=77&t=31440

**Reported by:** valanths1990