### PR TITLE
Adding finer config options for drop of ChampionMobs.

### DIFF
--- a/dist/game/config/L2JMods.properties
+++ b/dist/game/config/L2JMods.properties
@@ -30,11 +30,20 @@ ChampionHp = 8
 # Hp Regen Multiplier for Champion mobs.
 ChampionHpRegen = 1.0
 
-# Standard rewards multiplier for Champion mobs.
-ChampionRewards = 8
+# Exp/Sp rewards multiplier for Champion mobs.
+ChampionRewardsExpSp = 8.0
 
-# Adena & Seal Stone rewards multiplier for Champion mobs.
-ChampionAdenasRewards = 1.0
+# Standard rewards chance multiplier for Champion mobs.
+ChampionRewardsChance = 8.0
+
+# Standard rewards amount multiplier for Champion mobs.
+ChampionRewardsAmount = 1.0
+
+# Adena & Seal Stone rewards chance multiplier for Champion mobs.
+ChampionAdenasRewardsChance = 1.0
+
+# Adena & Seal Stone rewards amount multiplier for Champion mobs.
+ChampionAdenasRewardsAmount = 1.0
 
 # P. Attack and M. Attack bonus for Champion mobs.
 ChampionAtk = 1.0

--- a/src/main/java/com/l2jserver/Config.java
+++ b/src/main/java/com/l2jserver/Config.java
@@ -674,8 +674,11 @@ public final class Config
 	public static int L2JMOD_CHAMP_MIN_LVL;
 	public static int L2JMOD_CHAMP_MAX_LVL;
 	public static int L2JMOD_CHAMPION_HP;
-	public static int L2JMOD_CHAMPION_REWARDS;
-	public static float L2JMOD_CHAMPION_ADENAS_REWARDS;
+	public static float L2JMOD_CHAMPION_REWARDS_EXP_SP;
+	public static float L2JMOD_CHAMPION_REWARDS_CHANCE;
+	public static float L2JMOD_CHAMPION_REWARDS_AMOUNT;
+	public static float L2JMOD_CHAMPION_ADENAS_REWARDS_CHANCE;
+	public static float L2JMOD_CHAMPION_ADENAS_REWARDS_AMOUNT;
 	public static float L2JMOD_CHAMPION_HP_REGEN;
 	public static float L2JMOD_CHAMPION_ATK;
 	public static float L2JMOD_CHAMPION_SPD_ATK;
@@ -2165,8 +2168,11 @@ public final class Config
 			L2JMOD_CHAMP_MAX_LVL = L2JModSettings.getInt("ChampionMaxLevel", 60);
 			L2JMOD_CHAMPION_HP = L2JModSettings.getInt("ChampionHp", 7);
 			L2JMOD_CHAMPION_HP_REGEN = L2JModSettings.getFloat("ChampionHpRegen", 1);
-			L2JMOD_CHAMPION_REWARDS = L2JModSettings.getInt("ChampionRewards", 8);
-			L2JMOD_CHAMPION_ADENAS_REWARDS = L2JModSettings.getFloat("ChampionAdenasRewards", 1);
+			L2JMOD_CHAMPION_REWARDS_EXP_SP = L2JModSettings.getFloat("ChampionRewardsExpSp", 8);
+			L2JMOD_CHAMPION_REWARDS_CHANCE = L2JModSettings.getFloat("ChampionRewardsChance", 8);
+			L2JMOD_CHAMPION_REWARDS_AMOUNT = L2JModSettings.getFloat("ChampionRewardsAmount", 1);
+			L2JMOD_CHAMPION_ADENAS_REWARDS_CHANCE = L2JModSettings.getFloat("ChampionAdenasRewardsChance", 1);
+			L2JMOD_CHAMPION_ADENAS_REWARDS_AMOUNT = L2JModSettings.getFloat("ChampionAdenasRewardsAmount", 1);
 			L2JMOD_CHAMPION_ATK = L2JModSettings.getFloat("ChampionAtk", 1);
 			L2JMOD_CHAMPION_SPD_ATK = L2JModSettings.getFloat("ChampionSpdAtk", 1);
 			L2JMOD_CHAMPION_REWARD_LOWER_LVL_ITEM_CHANCE = L2JModSettings.getInt("ChampionRewardLowerLvlItemChance", 0);
@@ -3451,11 +3457,20 @@ public final class Config
 			case "championhpregen":
 				L2JMOD_CHAMPION_HP_REGEN = Float.parseFloat(pValue);
 				break;
-			case "championrewards":
-				L2JMOD_CHAMPION_REWARDS = Integer.parseInt(pValue);
+			case "championrewardsexpsp":
+				L2JMOD_CHAMPION_REWARDS_EXP_SP = Float.parseFloat(pValue);
 				break;
-			case "championadenasrewards":
-				L2JMOD_CHAMPION_ADENAS_REWARDS = Float.parseFloat(pValue);
+			case "championrewardschance":
+				L2JMOD_CHAMPION_REWARDS_CHANCE = Float.parseFloat(pValue);
+				break;
+			case "championrewardsamount":
+				L2JMOD_CHAMPION_REWARDS_AMOUNT = Float.parseFloat(pValue);
+				break;
+			case "championadenasrewardschance":
+				L2JMOD_CHAMPION_ADENAS_REWARDS_CHANCE = Float.parseFloat(pValue);
+				break;
+			case "championadenasrewardsamount":
+				L2JMOD_CHAMPION_ADENAS_REWARDS_AMOUNT = Float.parseFloat(pValue);
 				break;
 			case "championatk":
 				L2JMOD_CHAMPION_ATK = Float.parseFloat(pValue);

--- a/src/main/java/com/l2jserver/gameserver/model/actor/L2Attackable.java
+++ b/src/main/java/com/l2jserver/gameserver/model/actor/L2Attackable.java
@@ -472,8 +472,8 @@ public class L2Attackable extends L2Npc
 							
 							if (Config.L2JMOD_CHAMPION_ENABLE && isChampion())
 							{
-								exp *= Config.L2JMOD_CHAMPION_REWARDS;
-								sp *= Config.L2JMOD_CHAMPION_REWARDS;
+								exp *= Config.L2JMOD_CHAMPION_REWARDS_EXP_SP;
+								sp *= Config.L2JMOD_CHAMPION_REWARDS_EXP_SP;
 							}
 							
 							exp *= penalty;
@@ -581,8 +581,8 @@ public class L2Attackable extends L2Npc
 						
 						if (Config.L2JMOD_CHAMPION_ENABLE && isChampion())
 						{
-							exp *= Config.L2JMOD_CHAMPION_REWARDS;
-							sp *= Config.L2JMOD_CHAMPION_REWARDS;
+							exp *= Config.L2JMOD_CHAMPION_REWARDS_EXP_SP;
+							sp *= Config.L2JMOD_CHAMPION_REWARDS_EXP_SP;
 						}
 						
 						exp *= partyMul;
@@ -989,7 +989,7 @@ public class L2Attackable extends L2Npc
 				}
 				
 				// Broadcast message if RaidBoss was defeated
-				if (isRaid() && !isRaidMinion() && drop.getCount() > 0)
+				if (isRaid() && !isRaidMinion() && (drop.getCount() > 0))
 				{
 					final SystemMessage sm = SystemMessage.getSystemMessage(SystemMessageId.C1_DIED_DROPPED_S3_S2);
 					sm.addCharName(this);

--- a/src/main/java/com/l2jserver/gameserver/model/drops/strategy/IAmountMultiplierStrategy.java
+++ b/src/main/java/com/l2jserver/gameserver/model/drops/strategy/IAmountMultiplierStrategy.java
@@ -22,6 +22,7 @@ import com.l2jserver.Config;
 import com.l2jserver.gameserver.datatables.ItemTable;
 import com.l2jserver.gameserver.model.actor.L2Character;
 import com.l2jserver.gameserver.model.drops.GeneralDropItem;
+import com.l2jserver.gameserver.model.itemcontainer.Inventory;
 
 /**
  * @author Battlecruiser
@@ -37,7 +38,10 @@ public interface IAmountMultiplierStrategy
 		return (item, victim) ->
 		{
 			double multiplier = 1;
-			
+			if (victim.isChampion())
+			{
+				multiplier *= item.getItemId() != Inventory.ADENA_ID ? Config.L2JMOD_CHAMPION_REWARDS_AMOUNT : Config.L2JMOD_CHAMPION_ADENAS_REWARDS_AMOUNT;
+			}
 			Float dropAmountMultiplier = Config.RATE_DROP_AMOUNT_MULTIPLIER.get(item.getItemId());
 			if (dropAmountMultiplier != null)
 			{

--- a/src/main/java/com/l2jserver/gameserver/model/drops/strategy/IChanceMultiplierStrategy.java
+++ b/src/main/java/com/l2jserver/gameserver/model/drops/strategy/IChanceMultiplierStrategy.java
@@ -38,11 +38,11 @@ public interface IChanceMultiplierStrategy
 		double championmult;
 		if ((item.getItemId() == Inventory.ADENA_ID) || (item.getItemId() == Inventory.ANCIENT_ADENA_ID))
 		{
-			championmult = Config.L2JMOD_CHAMPION_ADENAS_REWARDS;
+			championmult = Config.L2JMOD_CHAMPION_ADENAS_REWARDS_CHANCE;
 		}
 		else
 		{
-			championmult = Config.L2JMOD_CHAMPION_REWARDS;
+			championmult = Config.L2JMOD_CHAMPION_REWARDS_CHANCE;
 		}
 		
 		return (Config.L2JMOD_CHAMPION_ENABLE && (victim != null) && victim.isChampion()) ? (Config.RATE_QUEST_DROP * championmult) : Config.RATE_QUEST_DROP;
@@ -55,7 +55,7 @@ public interface IChanceMultiplierStrategy
 			float multiplier = 1;
 			if (victim.isChampion())
 			{
-				multiplier *= item.getItemId() != Inventory.ADENA_ID ? Config.L2JMOD_CHAMPION_REWARDS : Config.L2JMOD_CHAMPION_ADENAS_REWARDS;
+				multiplier *= item.getItemId() != Inventory.ADENA_ID ? Config.L2JMOD_CHAMPION_REWARDS_CHANCE : Config.L2JMOD_CHAMPION_ADENAS_REWARDS_CHANCE;
 			}
 			Float dropChanceMultiplier = Config.RATE_DROP_CHANCE_MULTIPLIER.get(item.getItemId());
 			if (dropChanceMultiplier != null)

--- a/src/main/java/com/l2jserver/gameserver/model/events/AbstractScript.java
+++ b/src/main/java/com/l2jserver/gameserver/model/events/AbstractScript.java
@@ -2289,16 +2289,17 @@ public abstract class AbstractScript implements INamable
 		dropChance *= Config.RATE_QUEST_DROP; // TODO separate configs for rate and amount
 		if ((npc != null) && Config.L2JMOD_CHAMPION_ENABLE && npc.isChampion())
 		{
-			dropChance *= Config.L2JMOD_CHAMPION_REWARDS;
 			if ((itemId == Inventory.ADENA_ID) || (itemId == Inventory.ANCIENT_ADENA_ID))
 			{
-				minAmount *= Config.L2JMOD_CHAMPION_ADENAS_REWARDS;
-				maxAmount *= Config.L2JMOD_CHAMPION_ADENAS_REWARDS;
+				dropChance *= Config.L2JMOD_CHAMPION_ADENAS_REWARDS_CHANCE;
+				minAmount *= Config.L2JMOD_CHAMPION_ADENAS_REWARDS_AMOUNT;
+				maxAmount *= Config.L2JMOD_CHAMPION_ADENAS_REWARDS_AMOUNT;
 			}
 			else
 			{
-				minAmount *= Config.L2JMOD_CHAMPION_REWARDS;
-				maxAmount *= Config.L2JMOD_CHAMPION_REWARDS;
+				dropChance *= Config.L2JMOD_CHAMPION_REWARDS_CHANCE;
+				minAmount *= Config.L2JMOD_CHAMPION_REWARDS_AMOUNT;
+				maxAmount *= Config.L2JMOD_CHAMPION_REWARDS_AMOUNT;
 			}
 		}
 		


### PR DESCRIPTION
I ran into some issues regarding PreciseDropCalculation. If this is disabled, the chance for drops of Champion Mob was increased, but the amount of it wasn't. Of course, that's the intention of PreciseDropCalculation being disabled, however my community wasn't happy about that. 

So we (worked with Digitizer) managed to split it into chance & amount for both adena and item rewards and thought, it would be nice to be implemented by L2J too.