### PR TITLE
Fix suicide skills

### DIFF
--- a/src/main/java/com/l2jserver/gameserver/model/skills/Skill.java
+++ b/src/main/java/com/l2jserver/gameserver/model/skills/Skill.java
@@ -1558,6 +1558,11 @@ public final class Skill implements IIdentifiable
 				caster.setChargedShot(ShotType.SOULSHOTS, false);
 			}
 		}
+		
+		if (isSuicideAttack())
+		{
+			caster.doDie(caster);
+		}
 	}
 	
 	public void attach(FuncTemplate f)


### PR DESCRIPTION
## Summary

Fix suicide skills: it should suicide the caster when the skill finishs, not when the effect is applied on first target (if it's an area skill, like Boom attack). Also, i think the suicide parameter on skill is not attached to MagicalAttack effect, so it's independent.

**Note:** need DP part.

## Report

http://www.l2jserver.com/forum/viewtopic.php?f=77&t=29713

**Reported by** Zephyr