### PR TITLE
Rewritting Attackable AI

### DIFF
--- a/src/main/java/com/l2jserver/gameserver/ai/L2AttackableAI.java
+++ b/src/main/java/com/l2jserver/gameserver/ai/L2AttackableAI.java
@@ -28,12 +28,14 @@ import java.util.Set;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.l2jserver.Config;
 import com.l2jserver.gameserver.GameTimeController;
 import com.l2jserver.gameserver.GeoData;
 import com.l2jserver.gameserver.ThreadPoolManager;
 import com.l2jserver.gameserver.data.sql.impl.TerritoryTable;
-import com.l2jserver.gameserver.data.xml.impl.NpcData;
 import com.l2jserver.gameserver.enums.AISkillScope;
 import com.l2jserver.gameserver.enums.AIType;
 import com.l2jserver.gameserver.instancemanager.DimensionalRiftManager;
@@ -54,7 +56,6 @@ import com.l2jserver.gameserver.model.actor.instance.L2PcInstance;
 import com.l2jserver.gameserver.model.actor.instance.L2RaidBossInstance;
 import com.l2jserver.gameserver.model.actor.instance.L2RiftInvaderInstance;
 import com.l2jserver.gameserver.model.actor.instance.L2StaticObjectInstance;
-import com.l2jserver.gameserver.model.actor.templates.L2NpcTemplate;
 import com.l2jserver.gameserver.model.effects.L2EffectType;
 import com.l2jserver.gameserver.model.events.EventDispatcher;
 import com.l2jserver.gameserver.model.events.impl.character.npc.attackable.OnAttackableFactionCall;
@@ -69,9 +70,12 @@ import com.l2jserver.util.Rnd;
 
 /**
  * This class manages AI of L2Attackable.
+ * @author Zoey76
  */
 public class L2AttackableAI extends L2CharacterAI implements Runnable
 {
+	private static final Logger LOG = LoggerFactory.getLogger(L2AttackableAI.class);
+	
 	/**
 	 * Fear task.
 	 * @author Zoey76
@@ -114,7 +118,6 @@ public class L2AttackableAI extends L2CharacterAI implements Runnable
 	
 	private int _timePass = 0;
 	private int _chaosTime = 0;
-	private final L2NpcTemplate _skillrender;
 	private int _lastBuffTick;
 	// Fear parameters
 	private int _fearTime;
@@ -127,7 +130,6 @@ public class L2AttackableAI extends L2CharacterAI implements Runnable
 	public L2AttackableAI(L2Attackable creature)
 	{
 		super(creature);
-		_skillrender = NpcData.getInstance().getTemplate(getActiveChar().getTemplate().getId());
 		_attackTimeout = Integer.MAX_VALUE;
 		_globalAggro = -10; // 10 seconds timeout of ATTACK after respawn
 	}
@@ -380,11 +382,7 @@ public class L2AttackableAI extends L2CharacterAI implements Runnable
 				super.changeIntention(AI_INTENTION_IDLE, null, null);
 				
 				// Stop AI task and detach AI from NPC
-				if (_aiTask != null)
-				{
-					_aiTask.cancel(true);
-					_aiTask = null;
-				}
+				stopAITask();
 				
 				// Cancel the AI
 				_actor.detachAI();
@@ -413,11 +411,18 @@ public class L2AttackableAI extends L2CharacterAI implements Runnable
 		// self and buffs
 		if ((_lastBuffTick + 30) < GameTimeController.getInstance().getGameTicks())
 		{
-			for (Skill sk : _skillrender.getAISkills(AISkillScope.BUFF))
+			for (Skill buff : getActiveChar().getTemplate().getAISkills(AISkillScope.BUFF))
 			{
-				if (cast(sk))
+				if (checkSkillCastConditions(getActiveChar(), buff))
 				{
-					break;
+					if (!_actor.isAffectedBySkill(buff.getId()))
+					{
+						_actor.setTarget(_actor);
+						_actor.doCast(buff);
+						_actor.setTarget(target);
+						LOG.debug("{} used buff skill {} on {}", this, buff, _actor);
+						break;
+					}
 				}
 			}
 			_lastBuffTick = GameTimeController.getInstance().getGameTicks();
@@ -663,7 +668,7 @@ public class L2AttackableAI extends L2CharacterAI implements Runnable
 			}
 			else if (Rnd.nextInt(RANDOM_WALK_RATE) == 0)
 			{
-				for (Skill sk : _skillrender.getAISkills(AISkillScope.BUFF))
+				for (Skill sk : npc.getTemplate().getAISkills(AISkillScope.BUFF))
 				{
 					if (cast(sk))
 					{
@@ -680,7 +685,7 @@ public class L2AttackableAI extends L2CharacterAI implements Runnable
 			int z1 = 0;
 			final int range = Config.MAX_DRIFT_RANGE;
 			
-			for (Skill sk : _skillrender.getAISkills(AISkillScope.BUFF))
+			for (Skill sk : npc.getTemplate().getAISkills(AISkillScope.BUFF))
 			{
 				if (cast(sk))
 				{
@@ -688,7 +693,7 @@ public class L2AttackableAI extends L2CharacterAI implements Runnable
 				}
 			}
 			
-			// If NPC with random coord in territory - old method (for backward compartibility)
+			// If NPC with random coord in territory - old method (for backward compatibility)
 			if ((npc.getSpawn().getX() == 0) && (npc.getSpawn().getY() == 0) && (npc.getSpawn().getSpawnTerritory() == null))
 			{
 				// Calculate a destination point in the spawn area
@@ -737,8 +742,6 @@ public class L2AttackableAI extends L2CharacterAI implements Runnable
 					z1 = npc.getZ();
 				}
 			}
-			
-			// _log.debug("Current pos ("+getX()+", "+getY()+"), moving to ("+x1+", "+y1+").");
 			// Move the actor to Location (x,y,z) server side AND client side by sending Server->Client packet CharMoveToLocation (broadcast)
 			final Location moveLoc = GeoData.getInstance().moveCheck(npc.getX(), npc.getY(), npc.getZ(), x1, y1, z1, npc.getInstanceId());
 			
@@ -754,9 +757,8 @@ public class L2AttackableAI extends L2CharacterAI implements Runnable
 	 * <li>Call all L2Object of its Faction inside the Faction Range</li>
 	 * <li>Chose a target and order to attack it with magic skill or physical attack</li>
 	 * </ul>
-	 * TODO: Manage casting rules to healer mobs (like Ant Nurses)
 	 */
-	protected void thinkAttack()
+	protected synchronized void thinkAttack()
 	{
 		final L2Attackable npc = getActiveChar();
 		if (npc.isCastingNow())
@@ -788,13 +790,11 @@ public class L2AttackableAI extends L2CharacterAI implements Runnable
 		Set<Integer> clans = getActiveChar().getTemplate().getClans();
 		if ((clans != null) && !clans.isEmpty())
 		{
-			int factionRange = npc.getTemplate().getClanHelpRange() + collision;
+			final int factionRange = npc.getTemplate().getClanHelpRange() + collision;
 			// Go through all L2Object that belong to its faction
-			Collection<L2Object> objs = npc.getKnownList().getKnownObjects().values();
-			
 			try
 			{
-				for (L2Object obj : objs)
+				for (L2Object obj : npc.getKnownList().getKnownCharactersInRadius(factionRange))
 				{
 					if (obj instanceof L2Npc)
 					{
@@ -806,7 +806,7 @@ public class L2AttackableAI extends L2CharacterAI implements Runnable
 						}
 						
 						// Check if the L2Object is inside the Faction Range of the actor
-						if (npc.isInsideRadius(called, factionRange, true, false) && called.hasAI())
+						if (called.hasAI())
 						{
 							if ((Math.abs(originalAttackTarget.getZ() - called.getZ()) < 600) && npc.getAttackByList().contains(originalAttackTarget) && ((called.getAI()._intention == CtrlIntention.AI_INTENTION_IDLE) || (called.getAI()._intention == CtrlIntention.AI_INTENTION_ACTIVE)) && (called.getInstanceId() == npc.getInstanceId()))
 							{
@@ -840,7 +840,7 @@ public class L2AttackableAI extends L2CharacterAI implements Runnable
 			}
 			catch (NullPointerException e)
 			{
-				_log.warn("{}: There has been a problem trying to think the attack!", getClass().getSimpleName(), e);
+				LOG.warn("{}: There has been a problem trying to think the attack!", getClass().getSimpleName(), e);
 			}
 		}
 		
@@ -862,30 +862,22 @@ public class L2AttackableAI extends L2CharacterAI implements Runnable
 		
 		final int combinedCollision = collision + mostHate.getTemplate().getCollisionRadius();
 		
-		List<Skill> aiSuicideSkills = _skillrender.getAISkills(AISkillScope.SUICIDE);
+		final List<Skill> aiSuicideSkills = npc.getTemplate().getAISkills(AISkillScope.SUICIDE);
 		if (!aiSuicideSkills.isEmpty() && ((int) ((npc.getCurrentHp() / npc.getMaxHp()) * 100) < 30))
 		{
-			final Skill skill = aiSuicideSkills.get(Rnd.nextInt(aiSuicideSkills.size()));
-			if (Util.checkIfInRange(skill.getAffectRange(), getActiveChar(), mostHate, false) && (Rnd.get(100) < Rnd.get(npc.getMinSkillChance(), npc.getMaxSkillChance())))
+			final Skill skill = aiSuicideSkills.get(Rnd.get(aiSuicideSkills.size()));
+			if (Util.checkIfInRange(skill.getAffectRange(), getActiveChar(), mostHate, false) && npc.hasSkillChance())
 			{
 				if (cast(skill))
 				{
+					LOG.debug("{} used suicide skill {}", this, skill);
 					return;
-				}
-				
-				for (Skill sk : aiSuicideSkills)
-				{
-					if (cast(sk))
-					{
-						return;
-					}
 				}
 			}
 		}
 		
 		// ------------------------------------------------------
-		// In case many mobs are trying to hit from same place, move a bit,
-		// circling around the target
+		// In case many mobs are trying to hit from same place, move a bit, circling around the target
 		// Note from Gnacik:
 		// On l2js because of that sometimes mobs don't attack player only running
 		// around player without any sense, so decrease chance for now
@@ -1025,11 +1017,12 @@ public class L2AttackableAI extends L2CharacterAI implements Runnable
 			}
 		}
 		
-		if (!_skillrender.getAISkills(AISkillScope.GENERAL).isEmpty())
+		final List<Skill> generalSkills = npc.getTemplate().getAISkills(AISkillScope.GENERAL);
+		if (!generalSkills.isEmpty())
 		{
 			// -------------------------------------------------------------------------------
 			// Heal Condition
-			List<Skill> aiHealSkills = _skillrender.getAISkills(AISkillScope.HEAL);
+			final List<Skill> aiHealSkills = npc.getTemplate().getAISkills(AISkillScope.HEAL);
 			if (!aiHealSkills.isEmpty())
 			{
 				double percentage = (npc.getCurrentHp() / npc.getMaxHp()) * 100;
@@ -1038,52 +1031,64 @@ public class L2AttackableAI extends L2CharacterAI implements Runnable
 					L2Character leader = npc.getLeader();
 					if ((leader != null) && !leader.isDead() && (Rnd.get(100) > ((leader.getCurrentHp() / leader.getMaxHp()) * 100)))
 					{
-						for (Skill sk : aiHealSkills)
+						for (Skill healSkill : aiHealSkills)
 						{
-							if (sk.getTargetType() == L2TargetType.SELF)
+							if (healSkill.getTargetType() == L2TargetType.SELF)
 							{
 								continue;
 							}
-							if (!checkSkillCastConditions(sk))
+							
+							if (!checkSkillCastConditions(npc, healSkill))
 							{
 								continue;
 							}
-							if (!Util.checkIfInRange((sk.getCastRange() + collision + leader.getTemplate().getCollisionRadius()), npc, leader, false) && !isParty(sk) && !npc.isMovementDisabled())
+							
+							if (!Util.checkIfInRange((healSkill.getCastRange() + collision + leader.getTemplate().getCollisionRadius()), npc, leader, false) && !isParty(healSkill) && !npc.isMovementDisabled())
 							{
-								moveToPawn(leader, sk.getCastRange() + collision + leader.getTemplate().getCollisionRadius());
+								moveToPawn(leader, healSkill.getCastRange() + collision + leader.getTemplate().getCollisionRadius());
 								return;
 							}
+							
 							if (GeoData.getInstance().canSeeTarget(npc, leader))
 							{
 								clientStopMoving(null);
+								final L2Object target = npc.getTarget();
 								npc.setTarget(leader);
-								clientStopMoving(null);
-								npc.doCast(sk);
+								npc.doCast(healSkill);
+								npc.setTarget(target);
+								LOG.debug("{} used heal skill {} on leader {}", this, healSkill, leader);
 								return;
 							}
 						}
 					}
 				}
+				
 				if (Rnd.get(100) < ((100 - percentage) / 3))
 				{
 					for (Skill sk : aiHealSkills)
 					{
-						if (!checkSkillCastConditions(sk))
+						if (!checkSkillCastConditions(npc, sk))
 						{
 							continue;
 						}
+						
 						clientStopMoving(null);
+						final L2Object target = npc.getTarget();
 						npc.setTarget(npc);
 						npc.doCast(sk);
+						npc.setTarget(target);
+						LOG.debug("{} used heal skill {} on itself", this, sk);
 						return;
 					}
 				}
+				
 				for (Skill sk : aiHealSkills)
 				{
-					if (!checkSkillCastConditions(sk))
+					if (!checkSkillCastConditions(npc, sk))
 					{
 						continue;
 					}
+					
 					if (sk.getTargetType() == L2TargetType.ONE)
 					{
 						for (L2Character obj : npc.getKnownList().getKnownCharactersInRadius(sk.getCastRange() + collision))
@@ -1093,24 +1098,29 @@ public class L2AttackableAI extends L2CharacterAI implements Runnable
 								continue;
 							}
 							
-							L2Attackable targets = ((L2Attackable) obj);
-							if (!((L2Attackable) obj).isInMyClan(npc))
+							final L2Attackable targets = (L2Attackable) obj;
+							if (!targets.isInMyClan(npc))
 							{
 								continue;
 							}
+							
 							percentage = (targets.getCurrentHp() / targets.getMaxHp()) * 100;
 							if (Rnd.get(100) < ((100 - percentage) / 10))
 							{
 								if (GeoData.getInstance().canSeeTarget(npc, targets))
 								{
 									clientStopMoving(null);
+									final L2Object target = npc.getTarget();
 									npc.setTarget(obj);
 									npc.doCast(sk);
+									npc.setTarget(target);
+									LOG.debug("{} used heal skill {} on {}", this, sk, obj);
 									return;
 								}
 							}
 						}
 					}
+					
 					if (isParty(sk))
 					{
 						clientStopMoving(null);
@@ -1119,9 +1129,10 @@ public class L2AttackableAI extends L2CharacterAI implements Runnable
 					}
 				}
 			}
+			
 			// -------------------------------------------------------------------------------
 			// Res Skill Condition
-			List<Skill> aiResSkills = _skillrender.getAISkills(AISkillScope.RES);
+			final List<Skill> aiResSkills = npc.getTemplate().getAISkills(AISkillScope.RES);
 			if (!aiResSkills.isEmpty())
 			{
 				if (npc.isMinion())
@@ -1135,28 +1146,35 @@ public class L2AttackableAI extends L2CharacterAI implements Runnable
 							{
 								continue;
 							}
-							if (!checkSkillCastConditions(sk))
+							
+							if (!checkSkillCastConditions(npc, sk))
 							{
 								continue;
 							}
+							
 							if (!Util.checkIfInRange((sk.getCastRange() + collision + leader.getTemplate().getCollisionRadius()), npc, leader, false) && !isParty(sk) && !npc.isMovementDisabled())
 							{
 								moveToPawn(leader, sk.getCastRange() + collision + leader.getTemplate().getCollisionRadius());
 								return;
 							}
+							
 							if (GeoData.getInstance().canSeeTarget(npc, leader))
 							{
 								clientStopMoving(null);
+								final L2Object target = npc.getTarget();
 								npc.setTarget(leader);
 								npc.doCast(sk);
+								npc.setTarget(target);
+								LOG.debug("{} used resurrection skill {} on leader {}", this, sk, leader);
 								return;
 							}
 						}
 					}
 				}
+				
 				for (Skill sk : aiResSkills)
 				{
-					if (!checkSkillCastConditions(sk))
+					if (!checkSkillCastConditions(npc, sk))
 					{
 						continue;
 					}
@@ -1179,20 +1197,25 @@ public class L2AttackableAI extends L2CharacterAI implements Runnable
 								if (GeoData.getInstance().canSeeTarget(npc, targets))
 								{
 									clientStopMoving(null);
+									final L2Object target = npc.getTarget();
 									npc.setTarget(obj);
 									npc.doCast(sk);
+									npc.setTarget(target);
+									LOG.debug("{} used heal skill {} on clan member {}", this, sk, obj);
 									return;
 								}
 							}
 						}
 					}
+					
 					if (isParty(sk))
 					{
 						clientStopMoving(null);
-						L2Object target = getAttackTarget();
+						final L2Object target = npc.getTarget();
 						npc.setTarget(npc);
 						npc.doCast(sk);
 						npc.setTarget(target);
+						LOG.debug("{} used heal skill {} on party", this, sk);
 						return;
 					}
 				}
@@ -1220,69 +1243,35 @@ public class L2AttackableAI extends L2CharacterAI implements Runnable
 		}
 		
 		setTimepass(0);
+		
 		// --------------------------------------------------------------------------------
-		// Skill Use
-		List<Skill> aiGeneralSkills = _skillrender.getAISkills(AISkillScope.GENERAL);
-		if (!aiGeneralSkills.isEmpty())
+		// Long/Short Range skill usage.
+		if (!npc.getShortRangeSkills().isEmpty() && npc.hasSkillChance())
 		{
-			if (Rnd.get(100) < Rnd.get(npc.getMinSkillChance(), npc.getMaxSkillChance()))
+			final Skill shortRangeSkill = npc.getShortRangeSkills().get(Rnd.get(npc.getShortRangeSkills().size()));
+			if (checkSkillCastConditions(npc, shortRangeSkill))
 			{
-				Skill skills = aiGeneralSkills.get(Rnd.nextInt(aiGeneralSkills.size()));
-				if (cast(skills))
-				{
-					return;
-				}
-				for (Skill sk : aiGeneralSkills)
-				{
-					if (cast(sk))
-					{
-						return;
-					}
-				}
+				clientStopMoving(null);
+				npc.doCast(shortRangeSkill);
+				LOG.debug("{} used short range skill {} on {}", this, shortRangeSkill, npc.getTarget());
+				return;
 			}
-			
-			// --------------------------------------------------------------------------------
-			// Long/Short Range skill usage.
-			if (npc.hasLSkill() || npc.hasSSkill())
+		}
+		
+		if (!npc.getLongRangeSkills().isEmpty() && npc.hasSkillChance())
+		{
+			final Skill longRangeSkill = npc.getLongRangeSkills().get(Rnd.get(npc.getLongRangeSkills().size()));
+			if (checkSkillCastConditions(npc, longRangeSkill))
 			{
-				final List<Skill> shortRangeSkills = shortRangeSkillRender();
-				if (!shortRangeSkills.isEmpty() && npc.hasSSkill() && (dist2 <= 150) && (Rnd.get(100) <= npc.getSSkillChance()))
-				{
-					final Skill shortRangeSkill = shortRangeSkills.get(Rnd.get(shortRangeSkills.size()));
-					if ((shortRangeSkill != null) && cast(shortRangeSkill))
-					{
-						return;
-					}
-					for (Skill sk : shortRangeSkills)
-					{
-						if ((sk != null) && cast(sk))
-						{
-							return;
-						}
-					}
-				}
-				
-				final List<Skill> longRangeSkills = longRangeSkillRender();
-				if (!longRangeSkills.isEmpty() && npc.hasLSkill() && (dist2 > 150) && (Rnd.get(100) <= npc.getLSkillChance()))
-				{
-					final Skill longRangeSkill = longRangeSkills.get(Rnd.get(longRangeSkills.size()));
-					if ((longRangeSkill != null) && cast(longRangeSkill))
-					{
-						return;
-					}
-					for (Skill sk : longRangeSkills)
-					{
-						if ((sk != null) && cast(sk))
-						{
-							return;
-						}
-					}
-				}
+				clientStopMoving(null);
+				npc.doCast(longRangeSkill);
+				LOG.debug("{} used long range skill {} on {}", this, longRangeSkill, npc.getTarget());
+				return;
 			}
 		}
 		
 		// --------------------------------------------------------------------------------
-		// Starts Melee or Primary Skill
+		// Starts melee attack
 		if ((dist2 > range) || !GeoData.getInstance().canSeeTarget(npc, mostHate))
 		{
 			if (npc.isMovementDisabled())
@@ -1304,54 +1293,7 @@ public class L2AttackableAI extends L2CharacterAI implements Runnable
 			return;
 		}
 		
-		melee(npc.getPrimarySkillId());
-	}
-	
-	private void melee(int type)
-	{
-		if (type != 0)
-		{
-			switch (type)
-			{
-				case -1:
-				{
-					for (Skill sk : _skillrender.getAISkills(AISkillScope.GENERAL))
-					{
-						if (cast(sk))
-						{
-							return;
-						}
-					}
-					break;
-				}
-				case 1:
-				{
-					for (Skill sk : _skillrender.getAISkills(AISkillScope.ATTACK))
-					{
-						if (cast(sk))
-						{
-							return;
-						}
-					}
-					break;
-				}
-				default:
-				{
-					for (Skill sk : _skillrender.getAISkills(AISkillScope.GENERAL))
-					{
-						if (sk.getId() == getActiveChar().getPrimarySkillId())
-						{
-							if (cast(sk))
-							{
-								return;
-							}
-						}
-					}
-					break;
-				}
-			}
-		}
-		
+		// Attacks target
 		_actor.doAttack(getAttackTarget());
 	}
 	
@@ -1363,16 +1305,11 @@ public class L2AttackableAI extends L2CharacterAI implements Runnable
 		}
 		
 		final L2Attackable caster = getActiveChar();
-		
-		if (caster.isCastingNow() && !sk.isSimultaneousCast())
+		if (!checkSkillCastConditions(caster, sk))
 		{
 			return false;
 		}
 		
-		if (!checkSkillCastConditions(sk))
-		{
-			return false;
-		}
 		if (getAttackTarget() == null)
 		{
 			if (caster.getMostHated() != null)
@@ -1854,6 +1791,7 @@ public class L2AttackableAI extends L2CharacterAI implements Runnable
 	/**
 	 * This AI task will start when ACTOR cannot move and attack range larger than distance
 	 */
+	// TODO(Zoey76): Rework this method.
 	private void movementDisable()
 	{
 		final L2Attackable npc = getActiveChar();
@@ -1879,16 +1817,16 @@ public class L2AttackableAI extends L2CharacterAI implements Runnable
 			}
 			
 			// Check if activeChar has any skill
-			if (!_skillrender.getAISkills(AISkillScope.GENERAL).isEmpty())
+			if (!npc.getTemplate().getAISkills(AISkillScope.GENERAL).isEmpty())
 			{
 				// -------------------------------------------------------------
 				// Try to stop the target or disable the target as priority
 				int random = Rnd.get(100);
 				if (!getAttackTarget().isImmobilized() && (random < 2))
 				{
-					for (Skill sk : _skillrender.getAISkills(AISkillScope.IMMOBILIZE))
+					for (Skill sk : npc.getTemplate().getAISkills(AISkillScope.IMMOBILIZE))
 					{
-						if (!checkSkillCastConditions(sk) || (((sk.getCastRange() + npc.getTemplate().getCollisionRadius() + getAttackTarget().getTemplate().getCollisionRadius()) <= dist2) && !canAura(sk)))
+						if (!checkSkillCastConditions(npc, sk) || (((sk.getCastRange() + npc.getTemplate().getCollisionRadius() + getAttackTarget().getTemplate().getCollisionRadius()) <= dist2) && !canAura(sk)))
 						{
 							continue;
 						}
@@ -1911,9 +1849,9 @@ public class L2AttackableAI extends L2CharacterAI implements Runnable
 				// Same as Above, but with Mute/FEAR etc....
 				if (random < 5)
 				{
-					for (Skill sk : _skillrender.getAISkills(AISkillScope.COT))
+					for (Skill sk : npc.getTemplate().getAISkills(AISkillScope.COT))
 					{
-						if (!checkSkillCastConditions(sk) || (((sk.getCastRange() + npc.getTemplate().getCollisionRadius() + getAttackTarget().getTemplate().getCollisionRadius()) <= dist2) && !canAura(sk)))
+						if (!checkSkillCastConditions(npc, sk) || (((sk.getCastRange() + npc.getTemplate().getCollisionRadius() + getAttackTarget().getTemplate().getCollisionRadius()) <= dist2) && !canAura(sk)))
 						{
 							continue;
 						}
@@ -1935,9 +1873,9 @@ public class L2AttackableAI extends L2CharacterAI implements Runnable
 				// -------------------------------------------------------------
 				if (random < 8)
 				{
-					for (Skill sk : _skillrender.getAISkills(AISkillScope.DEBUFF))
+					for (Skill sk : npc.getTemplate().getAISkills(AISkillScope.DEBUFF))
 					{
-						if (!checkSkillCastConditions(sk) || (((sk.getCastRange() + npc.getTemplate().getCollisionRadius() + getAttackTarget().getTemplate().getCollisionRadius()) <= dist2) && !canAura(sk)))
+						if (!checkSkillCastConditions(npc, sk) || (((sk.getCastRange() + npc.getTemplate().getCollisionRadius() + getAttackTarget().getTemplate().getCollisionRadius()) <= dist2) && !canAura(sk)))
 						{
 							continue;
 						}
@@ -1960,9 +1898,9 @@ public class L2AttackableAI extends L2CharacterAI implements Runnable
 				// Some side effect skill like CANCEL or NEGATE
 				if (random < 9)
 				{
-					for (Skill sk : _skillrender.getAISkills(AISkillScope.NEGATIVE))
+					for (Skill sk : npc.getTemplate().getAISkills(AISkillScope.NEGATIVE))
 					{
-						if (!checkSkillCastConditions(sk) || (((sk.getCastRange() + npc.getTemplate().getCollisionRadius() + getAttackTarget().getTemplate().getCollisionRadius()) <= dist2) && !canAura(sk)))
+						if (!checkSkillCastConditions(npc, sk) || (((sk.getCastRange() + npc.getTemplate().getCollisionRadius() + getAttackTarget().getTemplate().getCollisionRadius()) <= dist2) && !canAura(sk)))
 						{
 							continue;
 						}
@@ -1985,9 +1923,9 @@ public class L2AttackableAI extends L2CharacterAI implements Runnable
 				// Start ATK SKILL when nothing can be done
 				if ((npc.isMovementDisabled() || (npc.getAiType() == AIType.MAGE) || (npc.getAiType() == AIType.HEALER)))
 				{
-					for (Skill sk : _skillrender.getAISkills(AISkillScope.ATTACK))
+					for (Skill sk : npc.getTemplate().getAISkills(AISkillScope.ATTACK))
 					{
-						if (!checkSkillCastConditions(sk) || (((sk.getCastRange() + npc.getTemplate().getCollisionRadius() + getAttackTarget().getTemplate().getCollisionRadius()) <= dist2) && !canAura(sk)))
+						if (!checkSkillCastConditions(npc, sk) || (((sk.getCastRange() + npc.getTemplate().getCollisionRadius() + getAttackTarget().getTemplate().getCollisionRadius()) <= dist2) && !canAura(sk)))
 						{
 							continue;
 						}
@@ -2059,22 +1997,29 @@ public class L2AttackableAI extends L2CharacterAI implements Runnable
 				
 			}
 			
-			melee(npc.getPrimarySkillId());
+			// Attacks target
+			_actor.doAttack(getAttackTarget());
 		}
 		catch (NullPointerException e)
 		{
 			setIntention(AI_INTENTION_ACTIVE);
-			_log.warn("{}: {} - failed executing movementDisable()!", getClass().getSimpleName(), this, e);
+			LOG.warn("{}: {} - failed executing movementDisable()!", getClass().getSimpleName(), this, e);
 			return;
 		}
 	}
 	
 	/**
+	 * @param caster the caster
 	 * @param skill the skill to check.
 	 * @return {@code true} if the skill is available for casting {@code false} otherwise.
 	 */
-	private boolean checkSkillCastConditions(Skill skill)
+	private boolean checkSkillCastConditions(L2Attackable caster, Skill skill)
 	{
+		if (caster.isCastingNow() && !skill.isSimultaneousCast())
+		{
+			return false;
+		}
+		
 		// Not enough MP.
 		if (skill.getMpConsume() >= getActiveChar().getCurrentMp())
 		{
@@ -2575,26 +2520,6 @@ public class L2AttackableAI extends L2CharacterAI implements Runnable
 		}
 	}
 	
-	private List<Skill> longRangeSkillRender()
-	{
-		List<Skill> longRangeSkills = _skillrender.getAISkills(AISkillScope.LONG_RANGE);
-		if (longRangeSkills.isEmpty())
-		{
-			longRangeSkills = getActiveChar().getLongRangeSkill();
-		}
-		return longRangeSkills;
-	}
-	
-	private List<Skill> shortRangeSkillRender()
-	{
-		List<Skill> shortRangeSkills = _skillrender.getAISkills(AISkillScope.SHORT_RANGE);
-		if (shortRangeSkills.isEmpty())
-		{
-			shortRangeSkills = getActiveChar().getShortRangeSkill();
-		}
-		return shortRangeSkills;
-	}
-	
 	/**
 	 * Manage AI thinking actions of a L2Attackable.
 	 */
@@ -2628,7 +2553,7 @@ public class L2AttackableAI extends L2CharacterAI implements Runnable
 		}
 		catch (Exception e)
 		{
-			_log.warn("{}: {} -  onEvtThink() failed!", getClass().getSimpleName(), this, e);
+			LOG.warn("{}: {} - onEvtThink() failed!", getClass().getSimpleName(), this, e);
 		}
 		finally
 		{

--- a/src/main/java/com/l2jserver/gameserver/ai/L2CharacterAI.java
+++ b/src/main/java/com/l2jserver/gameserver/ai/L2CharacterAI.java
@@ -1629,7 +1629,7 @@ public class L2CharacterAI extends AbstractAI
 	
 	public boolean canParty(Skill sk)
 	{
-		if (sk.getTargetType() == L2TargetType.PARTY)
+		if (isParty(sk))
 		{
 			int count = 0;
 			int ccount = 0;

--- a/src/main/java/com/l2jserver/gameserver/data/xml/impl/NpcData.java
+++ b/src/main/java/com/l2jserver/gameserver/data/xml/impl/NpcData.java
@@ -508,98 +508,100 @@ public class NpcData implements IXmlReader
 							Map<AISkillScope, List<Skill>> aiSkillLists = null;
 							for (Skill skill : skills.values())
 							{
-								if (!skill.isPassive())
+								if (skill.isPassive())
 								{
-									if (aiSkillLists == null)
-									{
-										aiSkillLists = new EnumMap<>(AISkillScope.class);
-									}
+									continue;
+								}
+								
+								if (aiSkillLists == null)
+								{
+									aiSkillLists = new EnumMap<>(AISkillScope.class);
+								}
+								
+								final List<AISkillScope> aiSkillScopes = new ArrayList<>();
+								final AISkillScope shortOrLongRangeScope = skill.getCastRange() <= 150 ? AISkillScope.SHORT_RANGE : AISkillScope.LONG_RANGE;
+								if (skill.isSuicideAttack())
+								{
+									aiSkillScopes.add(AISkillScope.SUICIDE);
+								}
+								else
+								{
+									aiSkillScopes.add(AISkillScope.GENERAL);
 									
-									List<AISkillScope> aiSkillScopes = new ArrayList<>();
-									final AISkillScope shortOrLongRangeScope = skill.getCastRange() <= 150 ? AISkillScope.SHORT_RANGE : AISkillScope.SHORT_RANGE;
-									if (skill.isSuicideAttack())
+									if (skill.isContinuous())
 									{
-										aiSkillScopes.add(AISkillScope.SUICIDE);
-									}
-									else
-									{
-										aiSkillScopes.add(AISkillScope.GENERAL);
-										
-										if (skill.isContinuous())
+										if (!skill.isDebuff())
 										{
-											if (!skill.isDebuff())
-											{
-												aiSkillScopes.add(AISkillScope.BUFF);
-											}
-											else
-											{
-												aiSkillScopes.add(AISkillScope.DEBUFF);
-												aiSkillScopes.add(AISkillScope.COT);
-												aiSkillScopes.add(shortOrLongRangeScope);
-											}
+											aiSkillScopes.add(AISkillScope.BUFF);
 										}
 										else
 										{
-											if (skill.hasEffectType(L2EffectType.DISPEL, L2EffectType.DISPEL_BY_SLOT))
-											{
-												aiSkillScopes.add(AISkillScope.NEGATIVE);
-												aiSkillScopes.add(shortOrLongRangeScope);
-											}
-											else if (skill.hasEffectType(L2EffectType.HEAL))
-											{
-												aiSkillScopes.add(AISkillScope.HEAL);
-											}
-											else if (skill.hasEffectType(L2EffectType.PHYSICAL_ATTACK, L2EffectType.PHYSICAL_ATTACK_HP_LINK, L2EffectType.MAGICAL_ATTACK, L2EffectType.DEATH_LINK, L2EffectType.HP_DRAIN))
-											{
-												aiSkillScopes.add(AISkillScope.ATTACK);
-												aiSkillScopes.add(AISkillScope.UNIVERSAL);
-												aiSkillScopes.add(shortOrLongRangeScope);
-											}
-											else if (skill.hasEffectType(L2EffectType.SLEEP))
-											{
-												aiSkillScopes.add(AISkillScope.IMMOBILIZE);
-											}
-											else if (skill.hasEffectType(L2EffectType.STUN, L2EffectType.ROOT))
-											{
-												aiSkillScopes.add(AISkillScope.IMMOBILIZE);
-												aiSkillScopes.add(shortOrLongRangeScope);
-											}
-											else if (skill.hasEffectType(L2EffectType.MUTE, L2EffectType.FEAR))
-											{
-												aiSkillScopes.add(AISkillScope.COT);
-												aiSkillScopes.add(shortOrLongRangeScope);
-											}
-											else if (skill.hasEffectType(L2EffectType.PARALYZE))
-											{
-												aiSkillScopes.add(AISkillScope.IMMOBILIZE);
-												aiSkillScopes.add(shortOrLongRangeScope);
-											}
-											else if (skill.hasEffectType(L2EffectType.DMG_OVER_TIME, L2EffectType.DMG_OVER_TIME_PERCENT))
-											{
-												aiSkillScopes.add(shortOrLongRangeScope);
-											}
-											else if (skill.hasEffectType(L2EffectType.RESURRECTION))
-											{
-												aiSkillScopes.add(AISkillScope.RES);
-											}
-											else
-											{
-												aiSkillScopes.add(AISkillScope.UNIVERSAL);
-											}
+											aiSkillScopes.add(AISkillScope.DEBUFF);
+											aiSkillScopes.add(AISkillScope.COT);
+											aiSkillScopes.add(shortOrLongRangeScope);
 										}
+									}
+									else
+									{
+										if (skill.hasEffectType(L2EffectType.DISPEL, L2EffectType.DISPEL_BY_SLOT))
+										{
+											aiSkillScopes.add(AISkillScope.NEGATIVE);
+											aiSkillScopes.add(shortOrLongRangeScope);
+										}
+										else if (skill.hasEffectType(L2EffectType.HEAL))
+										{
+											aiSkillScopes.add(AISkillScope.HEAL);
+										}
+										else if (skill.hasEffectType(L2EffectType.PHYSICAL_ATTACK, L2EffectType.PHYSICAL_ATTACK_HP_LINK, L2EffectType.MAGICAL_ATTACK, L2EffectType.DEATH_LINK, L2EffectType.HP_DRAIN))
+										{
+											aiSkillScopes.add(AISkillScope.ATTACK);
+											aiSkillScopes.add(AISkillScope.UNIVERSAL);
+											aiSkillScopes.add(shortOrLongRangeScope);
+										}
+										else if (skill.hasEffectType(L2EffectType.SLEEP))
+										{
+											aiSkillScopes.add(AISkillScope.IMMOBILIZE);
+										}
+										else if (skill.hasEffectType(L2EffectType.STUN, L2EffectType.ROOT))
+										{
+											aiSkillScopes.add(AISkillScope.IMMOBILIZE);
+											aiSkillScopes.add(shortOrLongRangeScope);
+										}
+										else if (skill.hasEffectType(L2EffectType.MUTE, L2EffectType.FEAR))
+										{
+											aiSkillScopes.add(AISkillScope.COT);
+											aiSkillScopes.add(shortOrLongRangeScope);
+										}
+										else if (skill.hasEffectType(L2EffectType.PARALYZE))
+										{
+											aiSkillScopes.add(AISkillScope.IMMOBILIZE);
+											aiSkillScopes.add(shortOrLongRangeScope);
+										}
+										else if (skill.hasEffectType(L2EffectType.DMG_OVER_TIME, L2EffectType.DMG_OVER_TIME_PERCENT))
+										{
+											aiSkillScopes.add(shortOrLongRangeScope);
+										}
+										else if (skill.hasEffectType(L2EffectType.RESURRECTION))
+										{
+											aiSkillScopes.add(AISkillScope.RES);
+										}
+										else
+										{
+											aiSkillScopes.add(AISkillScope.UNIVERSAL);
+										}
+									}
+								}
+								
+								for (AISkillScope aiSkillScope : aiSkillScopes)
+								{
+									List<Skill> aiSkills = aiSkillLists.get(aiSkillScope);
+									if (aiSkills == null)
+									{
+										aiSkills = new ArrayList<>();
+										aiSkillLists.put(aiSkillScope, aiSkills);
 									}
 									
-									for (AISkillScope aiSkillScope : aiSkillScopes)
-									{
-										List<Skill> aiSkills = aiSkillLists.get(aiSkillScope);
-										if (aiSkills == null)
-										{
-											aiSkills = new ArrayList<>();
-											aiSkillLists.put(aiSkillScope, aiSkills);
-										}
-										
-										aiSkills.add(skill);
-									}
+									aiSkills.add(skill);
 								}
 							}
 							

--- a/src/main/java/com/l2jserver/gameserver/model/actor/L2Attackable.java
+++ b/src/main/java/com/l2jserver/gameserver/model/actor/L2Attackable.java
@@ -110,6 +110,7 @@ public class L2Attackable extends L2Npc
 	// Misc
 	private boolean _mustGiveExpSp;
 	protected int _onKillDelay = 5000;
+	private long _lastAttack;
 	
 	/**
 	 * Creates an attackable NPC.
@@ -1543,6 +1544,16 @@ public class L2Attackable extends L2Npc
 	public final int getOnKillDelay()
 	{
 		return _onKillDelay;
+	}
+	
+	public long getLastAttack()
+	{
+		return _lastAttack;
+	}
+	
+	public void setLastAttack(long lastAttack)
+	{
+		_lastAttack = lastAttack;
 	}
 	
 	/**

--- a/src/main/java/com/l2jserver/gameserver/model/actor/L2Character.java
+++ b/src/main/java/com/l2jserver/gameserver/model/actor/L2Character.java
@@ -5296,7 +5296,6 @@ public abstract class L2Character extends L2Object implements ISkillsHolder, IDe
 		// Remove all its Func objects from the L2Character calculator set
 		if (oldSkill != null)
 		{
-			
 			// Stop casting if this skill is used right now
 			if ((getLastSkillCast() != null) && isCastingNow())
 			{
@@ -5331,7 +5330,7 @@ public abstract class L2Character extends L2Object implements ISkillsHolder, IDe
 	 */
 	public final Collection<Skill> getAllSkills()
 	{
-		return new ArrayList<>(_skills.values());
+		return _skills.values();
 	}
 	
 	/**

--- a/src/main/java/com/l2jserver/gameserver/model/actor/L2Npc.java
+++ b/src/main/java/com/l2jserver/gameserver/model/actor/L2Npc.java
@@ -20,7 +20,6 @@ package com.l2jserver.gameserver.model.actor;
 
 import static com.l2jserver.gameserver.ai.CtrlIntention.AI_INTENTION_ACTIVE;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -87,7 +86,6 @@ import com.l2jserver.gameserver.model.items.L2Weapon;
 import com.l2jserver.gameserver.model.items.instance.L2ItemInstance;
 import com.l2jserver.gameserver.model.olympiad.Olympiad;
 import com.l2jserver.gameserver.model.skills.Skill;
-import com.l2jserver.gameserver.model.skills.targets.L2TargetType;
 import com.l2jserver.gameserver.model.variables.NpcVariables;
 import com.l2jserver.gameserver.model.zone.type.L2TownZone;
 import com.l2jserver.gameserver.network.SystemMessageId;
@@ -197,14 +195,6 @@ public class L2Npc extends L2Character
 		return getTemplate().getSpiritShotChance();
 	}
 	
-	/**
-	 * @return the primary attack skill Id
-	 */
-	public int getPrimarySkillId()
-	{
-		return getTemplate().getPrimarySkillId();
-	}
-	
 	public int getMinSkillChance()
 	{
 		return getTemplate().getMinSkillChance();
@@ -213,6 +203,15 @@ public class L2Npc extends L2Character
 	public int getMaxSkillChance()
 	{
 		return getTemplate().getMaxSkillChance();
+	}
+	
+	/**
+	 * Verifies if the NPC can cast a skill given the minimum and maximum skill chances.
+	 * @return {@code true} if the NPC has chances of casting a skill
+	 */
+	public boolean hasSkillChance()
+	{
+		return Rnd.get(100) < Rnd.get(getMinSkillChance(), getMaxSkillChance());
 	}
 	
 	public boolean canMove()
@@ -230,171 +229,58 @@ public class L2Npc extends L2Character
 		return getTemplate().getDodge();
 	}
 	
-	public int getSSkillChance()
+	public List<Skill> getLongRangeSkills()
 	{
-		return getTemplate().getShortRangeSkillChance();
+		return getTemplate().getAISkills(AISkillScope.LONG_RANGE);
 	}
 	
-	public int getLSkillChance()
+	public List<Skill> getShortRangeSkills()
 	{
-		return getTemplate().getLongRangeSkillChance();
-	}
-	
-	public boolean hasLSkill()
-	{
-		return getTemplate().getLongRangeSkillId() > 0;
-	}
-	
-	public boolean hasSSkill()
-	{
-		return getTemplate().getShortRangeSkillId() > 0;
-	}
-	
-	public List<Skill> getLongRangeSkill()
-	{
-		final List<Skill> skilldata = new ArrayList<>();
-		if (getTemplate().getLongRangeSkillId() == 0)
-		{
-			return skilldata;
-		}
-		
-		switch (getTemplate().getLongRangeSkillId())
-		{
-			case -1:
-			{
-				final Collection<Skill> skills = getAllSkills();
-				if (skills != null)
-				{
-					for (Skill sk : skills)
-					{
-						if ((sk == null) || sk.isPassive() || (sk.getTargetType() == L2TargetType.SELF))
-						{
-							continue;
-						}
-						
-						if (sk.getCastRange() >= 200)
-						{
-							skilldata.add(sk);
-						}
-					}
-				}
-				break;
-			}
-			case 1:
-			{
-				for (Skill sk : getTemplate().getAISkills(AISkillScope.UNIVERSAL))
-				{
-					if (sk.getCastRange() >= 200)
-					{
-						skilldata.add(sk);
-					}
-				}
-				break;
-			}
-			default:
-			{
-				for (Skill sk : getAllSkills())
-				{
-					if (sk.getId() == getTemplate().getLongRangeSkillId())
-					{
-						skilldata.add(sk);
-					}
-				}
-			}
-		}
-		return skilldata;
-	}
-	
-	public List<Skill> getShortRangeSkill()
-	{
-		final List<Skill> skilldata = new ArrayList<>();
-		if (getTemplate().getShortRangeSkillId() == 0)
-		{
-			return skilldata;
-		}
-		
-		switch (getTemplate().getShortRangeSkillId())
-		{
-			case -1:
-			{
-				Collection<Skill> skills = getAllSkills();
-				if (skills != null)
-				{
-					for (Skill sk : skills)
-					{
-						if ((sk == null) || sk.isPassive() || (sk.getTargetType() == L2TargetType.SELF))
-						{
-							continue;
-						}
-						if (sk.getCastRange() <= 200)
-						{
-							skilldata.add(sk);
-						}
-					}
-				}
-				break;
-			}
-			case 1:
-			{
-				for (Skill sk : getTemplate().getAISkills(AISkillScope.UNIVERSAL))
-				{
-					if (sk.getCastRange() <= 200)
-					{
-						skilldata.add(sk);
-					}
-				}
-				break;
-			}
-			default:
-			{
-				for (Skill sk : getAllSkills())
-				{
-					if (sk.getId() == getTemplate().getShortRangeSkillId())
-					{
-						skilldata.add(sk);
-					}
-				}
-			}
-		}
-		return skilldata;
+		return getTemplate().getAISkills(AISkillScope.SHORT_RANGE);
 	}
 	
 	/** Task launching the function onRandomAnimation() */
-	protected class RandomAnimationTask implements Runnable
+	protected static class RandomAnimationTask implements Runnable
 	{
-		private final Logger LOG = LoggerFactory.getLogger(RandomAnimationTask.class);
+		private static final Logger LOG = LoggerFactory.getLogger(RandomAnimationTask.class);
+		private final L2Npc _npc;
+		
+		protected RandomAnimationTask(L2Npc npc)
+		{
+			_npc = npc;
+		}
 		
 		@Override
 		public void run()
 		{
 			try
 			{
-				if (isMob())
+				if (_npc.isMob())
 				{
 					// Cancel further animation timers until intention is changed to ACTIVE again.
-					if (getAI().getIntention() != AI_INTENTION_ACTIVE)
+					if (_npc.getAI().getIntention() != AI_INTENTION_ACTIVE)
 					{
 						return;
 					}
 				}
 				else
 				{
-					if (!isInActiveRegion())
+					if (!_npc.isInActiveRegion())
 					{
 						return;
 					}
 				}
 				
-				if (!(isDead() || isStunned() || isSleeping() || isParalyzed()))
+				if (!(_npc.isDead() || _npc.isStunned() || _npc.isSleeping() || _npc.isParalyzed()))
 				{
-					onRandomAnimation(Rnd.get(2, 3));
+					_npc.onRandomAnimation(Rnd.get(2, 3));
 				}
 				
-				startRandomAnimationTimer();
+				_npc.startRandomAnimationTimer();
 			}
 			catch (Exception e)
 			{
-				LOG.error("{}", e);
+				LOG.error("There has been an error trying to perform a random animation for NPC {}!", _npc, e);
 			}
 		}
 	}
@@ -431,7 +317,7 @@ public class L2Npc extends L2Character
 		int interval = Rnd.get(minWait, maxWait) * 1000;
 		
 		// Create a RandomAnimation Task that will be launched after the calculated delay
-		_rAniTask = new RandomAnimationTask();
+		_rAniTask = new RandomAnimationTask(this);
 		ThreadPoolManager.getInstance().scheduleGeneral(_rAniTask, interval);
 	}
 	

--- a/src/main/java/com/l2jserver/gameserver/model/actor/templates/L2NpcTemplate.java
+++ b/src/main/java/com/l2jserver/gameserver/model/actor/templates/L2NpcTemplate.java
@@ -88,11 +88,6 @@ public final class L2NpcTemplate extends L2CharTemplate implements IIdentifiable
 	private int _spiritShotChance;
 	private int _minSkillChance;
 	private int _maxSkillChance;
-	private int _primarySkillId;
-	private int _shortRangeSkillId;
-	private int _shortRangeSkillChance;
-	private int _longRangeSkillId;
-	private int _longRangeSkillChance;
 	private Map<Integer, Skill> _skills;
 	private Map<AISkillScope, List<Skill>> _aiSkillLists;
 	private Set<Integer> _clans;
@@ -164,11 +159,6 @@ public final class L2NpcTemplate extends L2CharTemplate implements IIdentifiable
 		
 		_minSkillChance = set.getInt("minSkillChance", 7);
 		_maxSkillChance = set.getInt("maxSkillChance", 15);
-		_primarySkillId = set.getInt("primarySkillId", 0);
-		_shortRangeSkillId = set.getInt("shortRangeSkillId", 0);
-		_shortRangeSkillChance = set.getInt("shortRangeSkillChance", 0);
-		_longRangeSkillId = set.getInt("longRangeSkillId", 0);
-		_longRangeSkillChance = set.getInt("longRangeSkillChance", 0);
 		
 		_collisionRadiusGrown = set.getDouble("collisionRadiusGrown", 0);
 		_collisionHeightGrown = set.getDouble("collisionHeightGrown", 0);
@@ -390,31 +380,6 @@ public final class L2NpcTemplate extends L2CharTemplate implements IIdentifiable
 		return _maxSkillChance;
 	}
 	
-	public int getPrimarySkillId()
-	{
-		return _primarySkillId;
-	}
-	
-	public int getShortRangeSkillId()
-	{
-		return _shortRangeSkillId;
-	}
-	
-	public int getShortRangeSkillChance()
-	{
-		return _shortRangeSkillChance;
-	}
-	
-	public int getLongRangeSkillId()
-	{
-		return _longRangeSkillId;
-	}
-	
-	public int getLongRangeSkillChance()
-	{
-		return _longRangeSkillChance;
-	}
-	
 	@Override
 	public Map<Integer, Skill> getSkills()
 	{
@@ -423,18 +388,17 @@ public final class L2NpcTemplate extends L2CharTemplate implements IIdentifiable
 	
 	public void setSkills(Map<Integer, Skill> skills)
 	{
-		_skills = skills != null ? Collections.unmodifiableMap(skills) : Collections.<Integer, Skill> emptyMap();
+		_skills = skills != null ? Collections.unmodifiableMap(skills) : Collections.emptyMap();
 	}
 	
 	public List<Skill> getAISkills(AISkillScope aiSkillScope)
 	{
-		final List<Skill> aiSkills = _aiSkillLists.get(aiSkillScope);
-		return aiSkills != null ? aiSkills : Collections.<Skill> emptyList();
+		return _aiSkillLists.getOrDefault(aiSkillScope, Collections.emptyList());
 	}
 	
 	public void setAISkillLists(Map<AISkillScope, List<Skill>> aiSkillLists)
 	{
-		_aiSkillLists = aiSkillLists != null ? Collections.unmodifiableMap(aiSkillLists) : Collections.<AISkillScope, List<Skill>> emptyMap();
+		_aiSkillLists = aiSkillLists != null ? Collections.unmodifiableMap(aiSkillLists) : Collections.emptyMap();
 	}
 	
 	public Set<Integer> getClans()


### PR DESCRIPTION
- Using SLF4J logger.
- Typos in comments fixed.
- thinkAttack() will try to cast one random skill and not iterate over
all skills.
- Heal skills will keep original target after cast is completed.
- Fixed issue with long and short range skills being always null, using
always NPC template.
- Improved performance and memory usage.
- Removed AISkillScope.GENERAL skills from cast options.
- Long and short range skills will always use minimum and maximum skill
cast chance.
- Fixed issue with "primary skill ID" being always zero, removed faulty
logic.
- Avoiding "skillrender" template.
- Fixed NpcData typo where all skills are short range...
- Removed range condition when choosing a skill to cast.
- Now NPCs with only long range skills will be able to cast when enemy
is close.
- Short range skills are prefered, if enemy is far, will try to cast
long range skill.
- RandomAnimationTask is now a static class.
- Removed unsued parameter from NPC template.
- Fixed issue where NPCs buffed target instead of themselves.